### PR TITLE
Add gzip-hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 mason_packages
 .mason
 .toolchain
+vendor

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ distclean: clean
 	rm -rf .mason
 	rm -rf .toolchain
 	rm -f local.env
+	rm -rf vendor
 
 xcode: node_modules
 	./node_modules/.bin/node-pre-gyp configure -- -f xcode

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,8 @@
       'error_on_warnings%':'true',
       'system_includes': [
         "-isystem <(module_root_dir)/<!(node -e \"require('nan')\")",
-        "-isystem <(module_root_dir)/mason_packages/.link/include/"
+        "-isystem <(module_root_dir)/mason_packages/.link/include/",
+        "-isystem <(module_root_dir)/vendor/gzip-hpp/include/"
       ]
   },
   'targets': [

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -13,3 +13,10 @@ function install() {
 source local.env
 
 install protozero 1.5.1
+
+# install gzip-hpp headers
+if [ ! -d "vendor/gzip-hpp" ]
+then
+  mkdir -p vendor
+  git clone https://github.com/mapbox/gzip-hpp.git vendor/gzip-hpp --depth=1
+fi

--- a/src/mbtiles-geostats.cpp
+++ b/src/mbtiles-geostats.cpp
@@ -1,4 +1,6 @@
 #include "mbtiles-geostats.hpp"
+#include <protozero/pbf_reader.hpp>
+#include <gzip.hpp>
 #include <string>
 #include <iostream>
 
@@ -48,7 +50,7 @@ NAN_METHOD(MBTilesGeostats::New)
  * @example
  * var MBTilesGeostats = require('@mapbox/mbtiles-geostats');
  * var mbs = new MBTilesGeostats();
- * 
+ *
  * buffers.forEach(function(buffer) {
  *   mbs.addBuffer(buffer, function(err) {
  *       if (err) return new Error();
@@ -57,16 +59,19 @@ NAN_METHOD(MBTilesGeostats::New)
  */
 NAN_METHOD(MBTilesGeostats::addBuffer)
 {
-    // Peek into buffer (decompress), 
-    // grab stats 
+    // Peek into buffer (decompress),
+    // grab stats
     // put them to Map object (with some deduping logic)
     // then ditch Buffer
 
 
 
     // This is returning our MBTilesGeostats instance/object
-    auto* h = Nan::ObjectWrap::Unwrap<MBTilesGeostats>(info.Holder());  
+    auto* h = Nan::ObjectWrap::Unwrap<MBTilesGeostats>(info.Holder());
 
+    // test out gzip functionality
+    std::string uncompressed_data = "hello";
+    std::string compressed_data = gzip::compress(uncompressed_data);
 
     if (info.Length() >= 2) {
       // CALLBACK: ensure callback is a function
@@ -102,27 +107,27 @@ NAN_METHOD(MBTilesGeostats::addBuffer)
       // - you can derefence the pointer
       // No difference in performance
 
-     
+
       // Dereference example:
       // You have to make the class object modifiable (dont use "const") if you plan to modify a value within it
       MBTilesGeostats & stats = *h; // derefencing (when I want the value out of the pointer)
-      
+
       // not const because we're modifying the maps
       std::string & statsMap = stats.statsMap;
-      
+
       */
-      
+
       // Pointer index example:
       // "->"" is reaching through the pointer to get the actual object val
       std::string & oldString = h->statsMap; // This is a reference to statsMap var, since it's using "&"
-      
+
       // This is a fancy string function that take a buffer and its length,
       // and returns a char pointer/c string (const char*)
       // Beware: This is copying the data
       std::string data(node::Buffer::Data(buffer), node::Buffer::Length(buffer));
 
       // Reset old string reference to the new value
-      oldString = oldString + data; 
+      oldString = oldString + data;
 
     // now try gunzipping buffer
         // if it is already unzipped, go ahead
@@ -149,7 +154,7 @@ NAN_METHOD(MBTilesGeostats::addBuffer)
  * var mbs = new MBTilesGeostats();
  *
  * var stats = mbs.getStats();
- * 
+ *
  */
 NAN_METHOD(MBTilesGeostats::getStats)
 {


### PR DESCRIPTION
This adds gzip-hpp to a vendor/ directory by adding a little section to the install_deps.sh script. Once we publish in mason, we can install that way and remove the include added to binding.gyp. 

cc @GretaCB 